### PR TITLE
adding bind to tap event if exists

### DIFF
--- a/src/jquery.sidr.js
+++ b/src/jquery.sidr.js
@@ -248,8 +248,10 @@
 
       // If the plugin hasn't been initialized yet
       if ( ! data ) {
+        var evnt = "click";
+        if("ontouchstart" in document.documentElement) {evnt = "tap";}
         $this.data('sidr', name);
-        $this.click(function(e) {
+        $this.bind(evnt, function(e) {
           e.preventDefault();
           methods.toogle(name);
         });


### PR DESCRIPTION
I made a touch validation to bind tap events if supported. it's fired faster in touch devices.
