### PR TITLE
"Displace" option given ability to squish body.

### DIFF
--- a/src/jquery.sidr.js
+++ b/src/jquery.sidr.js
@@ -65,8 +65,8 @@
           displace = $menu.data('displace'),
           onOpen = $menu.data('onOpen'),
           onClose = $menu.data('onClose'),
-          bodyAnimation,
-          menuAnimation,
+          bodyAnimation = {},
+          menuAnimation = {},
           scrollTop,
           bodyClass = (name === 'sidr' ? 'sidr-open' : 'sidr-open ' + name + '-open');
 
@@ -89,15 +89,13 @@
         // Lock sidr
         sidrMoving = true;
 
-        // Left or right?
-        if(side === 'left') {
-          bodyAnimation = {left: menuWidth + 'px'};
-          menuAnimation = {left: '0px'};
+	//Set up displacement
+        if(displace == 'slide' || displace == 'squish') {
+          bodyAnimation[side] = menuWidth + 'px';
+	  if(displace == 'squish')
+            bodyAnimation['width'] = $body.width() - menuWidth;
         }
-        else {
-          bodyAnimation = {right: menuWidth + 'px'};
-          menuAnimation = {right: '0px'};
-        }
+        menuAnimation[side] = '0px';
 
         // Prepare page if container is body
         if($body.is('body')){
@@ -106,7 +104,7 @@
         }
 
         // Open menu
-        if(displace){
+        if(displace == 'slide' || displace == 'squish') {
           $body.addClass('sidr-animating').css({
             width: $body.width(),
             position: 'absolute'
@@ -142,15 +140,13 @@
         // Lock sidr
         sidrMoving = true;
 
-        // Right or left menu?
-        if(side === 'left') {
-          bodyAnimation = {left: 0};
-          menuAnimation = {left: '-' + menuWidth + 'px'};
-        }
-        else {
-          bodyAnimation = {right: 0};
-          menuAnimation = {right: '-' + menuWidth + 'px'};
-        }
+	//Set up displacement
+        if(displace == 'slide' || displace == 'squish') {
+          bodyAnimation[side] = 0;
+	  if(displace == 'squish')
+	    bodyAnimation['width'] = $body.width() + menuWidth;
+	}
+        menuAnimation[side] = '-' + menuWidth + 'px';
 
         // Close menu
         if($body.is('body')){
@@ -217,7 +213,7 @@
       source        : null,           // Override the source of the content.
       renaming      : true,           // The ids and classes will be prepended with a prefix when loading existent content
       body          : 'body',         // Page container selector,
-      displace: true, // Displace the body content or not
+      displace: 'shift', // Displace the body content or not
       onOpen        : function() {},  // Callback when sidr opened
       onClose       : function() {}   // Callback when sidr closed
     }, options);


### PR DESCRIPTION
I'm using sidr in a project of mine and made a small modification to it to resize the body so it fits on the screen with the menu open, and I thought I'd share it. "displace" now takes a string, or false.
-false makes the menu slide out without affecting the body.
-'slide' pushes the whole body aside, as it did before.
-'squish' resizes the body as the sidr slides out.
