### PR TITLE
fixed issues when resizing window while sidr is open

### DIFF
--- a/src/jquery.sidr.js
+++ b/src/jquery.sidr.js
@@ -278,6 +278,10 @@
       $.error('Invalid Sidr Source');
     }
 
+    $(window).on('resize', function () {
+      $.sidr('close', name);
+    });
+
     return this.each(function(){
       var $this = $(this),
           data = $this.data('sidr');


### PR DESCRIPTION
Inline styles added to the body cause weird results when resizing the window. So programmatically close Sidr on window resize.