### PR TITLE
enhancement the detect touch screen logic

### DIFF
--- a/src/jquery.sidr.js
+++ b/src/jquery.sidr.js
@@ -286,7 +286,10 @@
       if ( ! data ) {
 
         $this.data('sidr', name);
-        if('ontouchstart' in document.documentElement) {
+        var hasTouchEvent, isMobileUserAgent;
+        isMobileUserAgent = navigator.userAgent.match(/(Android|Backerry|iPhone|iPod|ios|iOS|iPad|WebOS|Symbian|Windows Phone|Phone)/i) != null;
+        hasTouchEvent = isMobileUserAgent ? ("ontouchstart" in document.documentElement) : false;
+        if(hasTouchEvent) {
           $this.bind('touchstart', function(e) {
             var theEvent = e.originalEvent.touches[0];
             this.touched = e.timeStamp;


### PR DESCRIPTION
find some broswers(e.g. firefox 30 in Mac OS 10.9) will has the ontouchstart attr in non-touchable device as a default behaviour, in this case the click function won't work.

I occur this issue with FF 30 in Mac OX 10.9, using the latest sidr source code.