### PR TITLE
Fixed reinitalization

### DIFF
--- a/src/jquery.sidr.js
+++ b/src/jquery.sidr.js
@@ -284,7 +284,9 @@
 
       // If the plugin hasn't been initialized yet
       if ( ! data ) {
-
+        
+        sidrOpened = false;
+        sidrMoving = false;
         $this.data('sidr', name);
         if('ontouchstart' in document.documentElement) {
           $this.bind('touchstart', function(e) {


### PR DESCRIPTION
Allows to work nicely with turbo links.

When using turbo links and doing
````
$(document).on("ready page:load", function() {
  // sidr
  $('#sidr_btn').sidr();
});
````
`sidr` would stop working after pressing a link on it. Because the state of `sidrOpened` was not reinitialized.
