### PR TITLE
removing sidr from jQuery animation queue

### DIFF
--- a/dist/jquery.sidr.js
+++ b/dist/jquery.sidr.js
@@ -110,8 +110,12 @@
           $body.addClass('sidr-animating').css({
             width: $body.width(),
             position: 'absolute'
-          }).animate(bodyAnimation, speed, function() {
-            $(this).addClass(bodyClass);
+          }).animate(bodyAnimation, {
+            queue: false, 
+            duration: speed, 
+            complete: function() {
+              $(this).addClass(bodyClass);
+            }
           });
         }
         else {
@@ -119,14 +123,18 @@
             $(this).addClass(bodyClass);
           }, speed);
         }
-        $menu.css('display', 'block').animate(menuAnimation, speed, function() {
-          sidrMoving = false;
-          sidrOpened = name;
-          // Callback
-          if(typeof callback === 'function') {
-            callback(name);
+        $menu.css('display', 'block').animate(menuAnimation, {
+          queue: false,
+          duration: speed, 
+          complete: function() {
+            sidrMoving = false;
+            sidrOpened = name;
+            // Callback
+            if(typeof callback === 'function') {
+              callback(name);
+            }
+            $body.removeClass('sidr-animating');
           }
-          $body.removeClass('sidr-animating');
         });
 
         // onOpen callback
@@ -157,18 +165,25 @@
           scrollTop = $html.scrollTop();
           $html.removeAttr('style').scrollTop(scrollTop);
         }
-        $body.addClass('sidr-animating').animate(bodyAnimation, speed).removeClass(bodyClass);
-        $menu.animate(menuAnimation, speed, function() {
-          $menu.removeAttr('style').hide();
-          $body.removeAttr('style');
-          $('html').removeAttr('style');
-          sidrMoving = false;
-          sidrOpened = false;
-          // Callback
-          if(typeof callback === 'function') {
-            callback(name);
+        $body.addClass('sidr-animating').animate(bodyAnimation, {
+          queue: false,
+          duration: speed
+        }).removeClass(bodyClass);
+        $menu.animate(menuAnimation, {
+          queue: false,
+          duration: speed, 
+          complete: function() {
+            $menu.removeAttr('style').hide();
+            $body.removeAttr('style');
+            $('html').removeAttr('style');
+            sidrMoving = false;
+            sidrOpened = false;
+            // Callback
+            if(typeof callback === 'function') {
+              callback(name);
+            }
+            $body.removeClass('sidr-animating');
           }
-          $body.removeClass('sidr-animating');
         });
 
         // onClose callback

--- a/src/jquery.sidr.js
+++ b/src/jquery.sidr.js
@@ -110,8 +110,12 @@
           $body.addClass('sidr-animating').css({
             width: $body.width(),
             position: 'absolute'
-          }).animate(bodyAnimation, speed, function() {
-            $(this).addClass(bodyClass);
+          }).animate(bodyAnimation, {
+            queue: false, 
+            duration: speed, 
+            complete: function() {
+              $(this).addClass(bodyClass);
+            }
           });
         }
         else {
@@ -119,14 +123,18 @@
             $(this).addClass(bodyClass);
           }, speed);
         }
-        $menu.css('display', 'block').animate(menuAnimation, speed, function() {
-          sidrMoving = false;
-          sidrOpened = name;
-          // Callback
-          if(typeof callback === 'function') {
-            callback(name);
+        $menu.css('display', 'block').animate(menuAnimation, {
+          queue: false,
+          duration: speed, 
+          complete: function() {
+            sidrMoving = false;
+            sidrOpened = name;
+            // Callback
+            if(typeof callback === 'function') {
+              callback(name);
+            }
+            $body.removeClass('sidr-animating');
           }
-          $body.removeClass('sidr-animating');
         });
 
         // onOpen callback
@@ -157,18 +165,25 @@
           scrollTop = $html.scrollTop();
           $html.removeAttr('style').scrollTop(scrollTop);
         }
-        $body.addClass('sidr-animating').animate(bodyAnimation, speed).removeClass(bodyClass);
-        $menu.animate(menuAnimation, speed, function() {
-          $menu.removeAttr('style').hide();
-          $body.removeAttr('style');
-          $('html').removeAttr('style');
-          sidrMoving = false;
-          sidrOpened = false;
-          // Callback
-          if(typeof callback === 'function') {
-            callback(name);
+        $body.addClass('sidr-animating').animate(bodyAnimation, {
+          queue: false,
+          duration: speed
+        }).removeClass(bodyClass);
+        $menu.animate(menuAnimation, {
+          queue: false,
+          duration: speed, 
+          complete: function() {
+            $menu.removeAttr('style').hide();
+            $body.removeAttr('style');
+            $('html').removeAttr('style');
+            sidrMoving = false;
+            sidrOpened = false;
+            // Callback
+            if(typeof callback === 'function') {
+              callback(name);
+            }
+            $body.removeClass('sidr-animating');
           }
-          $body.removeClass('sidr-animating');
         });
 
         // onClose callback


### PR DESCRIPTION
Animations are queued automatically using animate(), so in some instances some of sidr’s animations might wait until after the queue is emptied to perform. This change removes sidr from that queue.

The issue that prompted this change was using sidr on a site that was also using the [jquery.scrollTo library](https://github.com/flesler/jquery.scrollTo) in Chrome. The body animation was still turned on, but the body animation would always wait for the queued scrollTo animation to complete (this did not affect the separate menu animation). This change removes sidr's animations from the queue so this issue no longer occurs.