### PR TITLE
Added support for a settings "skip if has prefix" on attributes.

### DIFF
--- a/src/jquery.sidr.js
+++ b/src/jquery.sidr.js
@@ -32,16 +32,28 @@
     loadContent: function($menu, content) {
       $menu.html(content);
     },
+    // checks if a string (attribute) starts with
+    attribStartsWith: function(attribute, needle) {
+      if ( typeof needle === 'string' ) {
+        var rEx = new RegExp('\\b'+needle+'[\\w\\-_]+', 'i');
+        return rEx.test(attribute);
+      }
+      return false;
+    },
     // Add sidr prefixes
-    addPrefix: function($element) {
+    addPrefix: function($element, skipPrefix) {
       var elementId = $element.attr('id'),
           elementClass = $element.attr('class');
 
       if(typeof elementId === 'string' && '' !== elementId) {
-        $element.attr('id', elementId.replace(/([A-Za-z0-9_.\-]+)/g, 'sidr-id-$1'));
+          if ( ! privateMethods.attribStartsWith(elementId, skipPrefix) ) {
+          $element.attr('id', elementId.replace(/([A-Za-z0-9_.\-]+)/g, 'sidr-id-$1'));
+        }
       }
-      if(typeof elementClass === 'string' && '' !== elementClass && 'sidr-inner' !== elementClass) {
-        $element.attr('class', elementClass.replace(/([A-Za-z0-9_.\-]+)/g, 'sidr-class-$1'));
+      if(typeof elementClass === 'string' && '' !== elementClass) {
+        if ( ! privateMethods.attribStartsWith(elementClass, skipPrefix) &&  'sidr-inner' !== elementClass ) {
+          $element.attr('class', elementClass.replace(/([A-Za-z0-9_.\-]+)/g, 'sidr-class-$1'));
+        }
       }
       $element.removeAttr('style');
     },
@@ -216,6 +228,7 @@
       side          : 'left',         // Accepts 'left' or 'right'
       source        : null,           // Override the source of the content.
       renaming      : true,           // The ids and classes will be prepended with a prefix when loading existent content
+      skipPrefix    : false,          // If set to any string all classes and id starting with this prefix will not be renamed (useful for compatiblity)
       body          : 'body',         // Page container selector,
       displace: true, // Displace the body content or not
       onOpen        : function() {},  // Callback when sidr opened
@@ -268,7 +281,7 @@
         var $htmlContent = $('<div />').html(htmlContent);
         $htmlContent.find('*').each(function(index, element) {
           var $element = $(element);
-          privateMethods.addPrefix($element);
+          privateMethods.addPrefix($element, settings.skipPrefix);
         });
         htmlContent = $htmlContent.html();
       }


### PR DESCRIPTION
Hi, I was working with Sidr and Font-Awesome  and I needed Sidr to rewrite the id and classes but leave untouched the FA classes so i come up with this new setting ``skipPrefix`` that will be used to skip the rewrite of the classes starting with a specific prefix.

For *prefix* i intend:
- A complete class name.
- A class that starts with the prefix followed by a dash or an underscore.

Example (will skip the Font-Awsome classes):
```
    $("#menu-toggle").sidr({
      skipPrefix: 'fa',
      name: 'main-menu-left',
      side: 'left',
      source: '.navigation',
      displace: ( $win.width() < 480 ),
    });
```

This example will skip all the classes: ``fa``, ``fa-*`` and ``fa_*``.

*Bonus*: Since the parameter is put in a regex it's possible to pass something like ``((?:prefix1)|(prefix2))`` to look for more prefixes.


Esolitos