### PR TITLE
fixed issue with jumping hover/active effect.

### DIFF
--- a/src/scss/sidr/_base.scss
+++ b/src/scss/sidr/_base.scss
@@ -76,8 +76,6 @@
             border-top: 1px solid lighten($sidr-background, 10%);
             border-bottom: 1px solid darken($sidr-background, 10%);
 
-            &:hover,
-            &.active,
             &.sidr-class-active {
                 border-top: none;
                 line-height: 49px;
@@ -105,8 +103,6 @@
                         border-bottom: none;
                     }
 
-                    &:hover,
-                    &.active,
                     &.sidr-class-active {
                         border-top: none;
                         line-height: 41px;


### PR DESCRIPTION
there is a strange hover effect within the black and white theme of sidr.
you can observe the phenomenon on current sidr website, too.
This simple change will result in a smoother hover effekt while the "sidr-class-active" is still enabled.