### PR TITLE
Fix mouse click on touchscreen devices

### DIFF
--- a/src/jquery.sidr.js
+++ b/src/jquery.sidr.js
@@ -299,12 +299,10 @@
             }
           });
         }
-        else {
-          $this.click(function(e) {
-            e.preventDefault();
-            methods.toggle(name);
-          });
-        }
+        $this.click(function(e) {
+          e.preventDefault();
+          methods.toggle(name);
+        });
       }
     });
   };


### PR DESCRIPTION
Some devices have a touchscreen AND a mouse and keyboard. Clicking with a mouse should work on touchscreen devices too. This fixes it.