### PR TITLE
Added the ability to override the default 'toggle' method when binding to a click event

### DIFF
--- a/dist/jquery.sidr.js
+++ b/dist/jquery.sidr.js
@@ -219,7 +219,8 @@
       body          : 'body',         // Page container selector,
       displace: true, // Displace the body content or not
       onOpen        : function() {},  // Callback when sidr opened
-      onClose       : function() {}   // Callback when sidr closed
+      onClose       : function() {},  // Callback when sidr closed
+      method        : 'toggle'        // The method to call when element is clicked
     }, options);
 
     var name = settings.name,
@@ -295,14 +296,14 @@
             var delta = Math.abs(e.timeStamp - this.touched);
             if(delta < 200) {
               e.preventDefault();
-              methods.toggle(name);
+              methods[settings.method](name);
             }
           });
         }
         else {
           $this.click(function(e) {
             e.preventDefault();
-            methods.toggle(name);
+            methods[settings.method](name);
           });
         }
       }

--- a/src/jquery.sidr.js
+++ b/src/jquery.sidr.js
@@ -219,7 +219,8 @@
       body          : 'body',         // Page container selector,
       displace: true, // Displace the body content or not
       onOpen        : function() {},  // Callback when sidr opened
-      onClose       : function() {}   // Callback when sidr closed
+      onClose       : function() {},  // Callback when sidr closed
+      method        : 'toggle'        // The method to call when element is clicked
     }, options);
 
     var name = settings.name,
@@ -295,14 +296,14 @@
             var delta = Math.abs(e.timeStamp - this.touched);
             if(delta < 200) {
               e.preventDefault();
-              methods.toggle(name);
+              methods[settings.method](name);
             }
           });
         }
         else {
           $this.click(function(e) {
             e.preventDefault();
-            methods.toggle(name);
+            methods[settings.method](name);
           });
         }
       }


### PR DESCRIPTION
When initializing sidr using the following syntax, the #btn element's click event will call sidr's *toggle* method:

```
$('#btn').sidr({
  name: 'sidr-right',
  side: 'right'
});
```

This pull request offers a way to call an alternative to the *toggle* menu. For instance, suppose I only want #btn to open, but not close the sidr. I would change the above code to the following:

```
$('#btn').sidr({
  method: 'open',
  name: 'sidr-right',
  side: 'right'
});
```