### PR TITLE
updated single-box-shadow() for compass 1.0.1

### DIFF
--- a/src/scss/sidr/_base.scss
+++ b/src/scss/sidr/_base.scss
@@ -36,7 +36,7 @@
     font-size: $sidr-font-size;
     background: $sidr-background;
     color: $sidr-text-color;
-    @include single-box-shadow($sidr-background-shadow-color, 0, 0, 5px, 5px, inset);
+    @include single-box-shadow(0, 0, 5px, 5px, $sidr-background-shadow-color, inset);
 
     h1, h2, h3, h4, h5, h6 {
         font-size: $sidr-font-size - 4;
@@ -46,7 +46,7 @@
         color: $sidr-text-color;
         line-height: 24px;
         @include background-image(linear-gradient(lighten($sidr-background, 10%), darken($sidr-background, 10%)));
-        @include single-box-shadow(rgba(#000, .2), 0, 5px, 5px, 3px);
+        @include single-box-shadow(0, 5px, 5px, 3px, rgba(#000, .2));
     }
 
     p {
@@ -83,7 +83,7 @@
                 line-height: 49px;
 
                 > a, > span {
-                    @include single-box-shadow($sidr-background-shadow-color, 0, 0, 15px, 3px, inset);
+                    @include single-box-shadow(0, 0, 15px, 3px, $sidr-background-shadow-color, inset);
                 }
             }
 
@@ -112,7 +112,7 @@
                         line-height: 41px;
 
                         > a, > span {
-                            @include single-box-shadow($sidr-background-shadow-color, 0, 0, 15px, 3px, inset);
+                            @include single-box-shadow(0, 0, 15px, 3px, $sidr-background-shadow-color, inset);
                         }
                     }
 


### PR DESCRIPTION
The $color argument for single-box-shadow is now the 5th argument instead of the 1st.