### PR TITLE
Prevent viewport scaling when left menu is shown

### DIFF
--- a/dist/jquery.sidr.js
+++ b/dist/jquery.sidr.js
@@ -99,10 +99,10 @@
           menuAnimation = {right: '0px'};
         }
 
-        // Prepare page if container is body
+        // Prepare page if container is body (overflow-x hides the slid-over container while position prevents the slid-over container from causing the viewport to change scale)
         if($body.is('body')){
           scrollTop = $html.scrollTop();
-          $html.css('overflow-x', 'hidden').scrollTop(scrollTop);
+          $html.css({'overflow-x':'hidden', 'position':'fixed'}).scrollTop(scrollTop);
         }
 
         // Open menu

--- a/src/jquery.sidr.js
+++ b/src/jquery.sidr.js
@@ -99,10 +99,10 @@
           menuAnimation = {right: '0px'};
         }
 
-        // Prepare page if container is body
+        // Prepare page if container is body (overflow-x hides the slid-over container while position prevents the slid-over container from causing the viewport to change scale)
         if($body.is('body')){
           scrollTop = $html.scrollTop();
-          $html.css('overflow-x', 'hidden').scrollTop(scrollTop);
+          $html.css({'overflow-x':'hidden', 'position':'fixed'}).scrollTop(scrollTop);
         }
 
         // Open menu


### PR DESCRIPTION
iOS 8+ has the menu scale the page's viewport when a left menu is shown (iOS 9 [beta] even scales it when user-scaling is disabled). This seems to happen since `overflow-x:hidden;` is ignored when used on the HTML tag on mobile. This even happens on the demo site (http://www.berriart.com/sidr/).

This update simply adds `position:fixed;` in addition to `overflow-x:hidden;` when the menu is shown so that the overflow-x isn't ignored. This fixes the issue for left menus while leaving right menus working (they didn't scale the viewport like left menus did).

This has been tested on iOS 9 beta and desktop Safari & Chrome.