### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Sidr
+# Sidr
 
 [![Build Status](https://travis-ci.org/artberri/sidr.svg?branch=master)](https://travis-ci.org/artberri/sidr) [![Code Climate](https://codeclimate.com/github/artberri/sidr/badges/gpa.svg)](https://codeclimate.com/github/artberri/sidr) [![Test Coverage](https://codeclimate.com/github/artberri/sidr/badges/coverage.svg)](https://codeclimate.com/github/artberri/sidr/coverage) [![Dependency Status](https://david-dm.org/artberri/sidr.svg)](https://david-dm.org/artberri/sidr) [![npm version](https://img.shields.io/npm/v/sidr.svg)](https://npmjs.org/package/sidr) [![bower version](https://img.shields.io/bower/v/sidr.svg)](http://bower.io/) [![License](https://img.shields.io/npm/l/sidr.svg)](https://github.com/artberri/sidr/blob/master/LICENSE)
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
